### PR TITLE
Proposal 305: Repeal mutable rule 206

### DIFF
--- a/mutable_rules/206_Defeated-proposals.md
+++ b/mutable_rules/206_Defeated-proposals.md
@@ -1,2 +1,0 @@
-When a proposed rule-change is defeated, the player who proposed it loses 10
-points.

--- a/mutable_rules/306_Defeated-proposals-repealed.md
+++ b/mutable_rules/306_Defeated-proposals-repealed.md
@@ -1,0 +1,1 @@
+Repealed: When a proposed rule-change is defeated, the player who proposed it loses 10 points.


### PR DESCRIPTION
Sorry about the delay! 

Okay, so I noticed this one early on. Defeated proposals end up costing the victor 10 points. This means that if someone is ever within distance of winning the game, all the players must do is work to defeat the proposal! This could lead to a never ending game and result in important proposals being voted on unfairly just to cost someone 10 points.

It's bad enough to earn the less than maximum points in this game, subtracting ten points just adds insult to the fact that everyone thinks your proposal is bad.

On that note: please don't defeat this. ;(
