### PR TITLE
306: amend 304 for player file updates

### DIFF
--- a/mutable_rules/306_Github-repository.md
+++ b/mutable_rules/306_Github-repository.md
@@ -16,7 +16,16 @@ Pull Requests must perform exactly one of the following actions:
 4. Move a rule from either the immutable_rules directory or the mutable_rules
    directory to the other one, when a rule is transmuted.
 5. Create a new player file in the `players/` directory
-6. Perform some administrative task on the repository, at the discretion of the
+6. Update a player file with a representation of that player's latest score.
+   Pull Requests of this type can happen outside of the normal turn
+   order, and can be merged with the approval of one player other than the one
+   creating the pull request. In order to provide for rapid score updates for
+   the convenience of players, the changes made by such pull requests are
+   recognized as subject to error, and shall not be treated as authoritative
+   for the purpose of determining winners. Nor shall mistakes in the form or
+   meaning of these updates constitute a violation of this rule, but should
+   instead be addressed by simply making further updates by this rule.
+7. Perform some administrative task on the repository, at the discretion of the
    players. Pull Requests of this type can happen outside of the normal turn
    order, must be approved by majority vote of all players, and cannot
    materially affect the operation of the rules or the game. An example of this

--- a/mutable_rules/306_Github-repository.md
+++ b/mutable_rules/306_Github-repository.md
@@ -16,15 +16,10 @@ Pull Requests must perform exactly one of the following actions:
 4. Move a rule from either the immutable_rules directory or the mutable_rules
    directory to the other one, when a rule is transmuted.
 5. Create a new player file in the `players/` directory
-6. Update a player file with a representation of that player's latest score.
+6. Update a single player's file with a representation of their latest score.
    Pull Requests of this type can happen outside of the normal turn
    order, and can be merged with the approval of one player other than the one
-   creating the pull request. In order to provide for rapid score updates for
-   the convenience of players, the changes made by such pull requests are
-   recognized as subject to error, and shall not be treated as authoritative
-   for the purpose of determining winners. Nor shall mistakes in the form or
-   meaning of these updates constitute a violation of this rule, but should
-   instead be addressed by simply making further updates by this rule.
+   creating the pull request.
 7. Perform some administrative task on the repository, at the discretion of the
    players. Pull Requests of this type can happen outside of the normal turn
    order, must be approved by majority vote of all players, and cannot


### PR DESCRIPTION
I apologize in advance for the length of this rationale regarding proposal 306. Please read the diff. The diff is the important part, but the rationale is offered in case there are any initial questions.

Immutable rule 118 stipulates that "Each player's file must at all times contain the numeric score of the player." This is convenient, because players may not wish to sift through the log to recalculate scores, duplicating effort. However, neither rule 118 nor any other rule provides a mechanism for this to happen. Therefore, an undefined condition routinely arises where actual scores have changed, but these changes are not reflected in player files, violating rule 118. I believe the prevailing interpretation has been that this prevents advancement of game state until the player file is updated. Regardless, we need a mechanism to update the player files, and that mechanism should allow for prompt updates to reduce the duration of game hangs.

audiodude proposed the use of the admin power and as far as I can tell this is legal, insofar as the player files do not materially affect the operation of the rules. So I vowed to support any score update PR, which in a 3-player game practically assures such PRs will go through. This has apparently functioned pretty well, albeit a bit awkwardly. However, all this was intended as an interim measure. Using the admin power to do updates all the time is a bit scary because wherever it is used, it is hard to categorically rule out material changes to the operation of rules (and the possibility of having to retroactively determine the game state after many moves made on false assumptions seems terrible). So updates by the admin power realistically require more detailed auditing, adding to player burden. Using the admin power also requires a majority vote, which slows down updates (therefore suspending game state per 118) and is not strictly necessary anyway.  So it seems procedurally useful to make more specific provisions for player file updates. 

Therefore I added a clause to 304's enumeration of allowed PR types. This clause inherits from the administrative power the property of occurring outside the turn order, and it inherits from the current situation the property of only requiring one approval besides the mere proposal of the PR. This also means it is not necessary for score update PRs to be +1 by their authors, which would be an additional annoyance. The single +1 may also simply merge the PR, further facilitating these boring routine updates.

At the cost of increasing the volume of text I have included clarification that errors are allowed, not to encourage them but because they should not cause indeterminate states or hangs. It is better to resolve these conditions with further edits by the same rule, allowing score disputes to proceed asynchronously. These PRs would be a good place for discussions and disputes regarding score calculation.

Obviously it would not be a done thing to intentionally falsify or obfuscate the player files, it would defeat the purpose. And it is difficult to tease out intent and whether the updater made an innocent mistake or not. So if anybody wishes, we may consider proposals which somehow penalize inaccurate updates. But I don't recommend this, since making PRs for score updates is boring and incentivizing it in other ways (like adding points) will probably create problems (like racing to be the one with the merged update PR). I think clarifying that the player file scores are non-authoritative means this problem can reasonably be addressed through social shame.

I renumbered point 6 to point 7 in order to keep point 7 at the end, as the 'catchall'. This seemed more readable to me, even though it involved a renumbering.

I considered making this a separate rule, but that would require amendments in 304, which enumerates the only allowed PR types, so I just included this inline.

While this facilitates the existing practice of PR score updates, which should reduce hang time per rule 118, I don't think this is a complete and perfect solution, because rule 118 still hangs the game pending synchronization on scores. However, that's another issue and can be practically addressed by a custom of quickly PRing and +1/merging score updates at the end of each turn. Due to asynchrony and error tolerance, I believe this rule even permits ahead-of-time PRing of the score change in cases where the proposal has clearly passed, but the turn cannot advance yet because not all eligible voters have (irrelevantly) voted. 
