### PR TITLE
Proposal 309: Add fast vote option

### DIFF
--- a/mutable_rules/303_Eligible-voters.md
+++ b/mutable_rules/303_Eligible-voters.md
@@ -1,2 +1,0 @@
-Every player is an eligible voter. Every eligible voter must participate in
-every vote on rule-changes.

--- a/mutable_rules/309_Eligible-voters.md
+++ b/mutable_rules/309_Eligible-voters.md
@@ -1,0 +1,13 @@
+Every player is an eligible voter.
+
+If the number of votes on a rule-change reaches a number sufficient for
+adoption, the proponent of the rule-change has the option to merge and close
+the pull request at that time, without waiting for all eligible voters to
+participate.
+
+For example, if the rules say that a rule-change is adopted by a simple
+majority vote, and there are 3 players, then the proponent may merge and close
+as long as there are two +1 votes.
+
+When this option is exercised, players who did not already vote are counted as
+having voted against.


### PR DESCRIPTION
This rule-change amends rule 303.

When there are (say) 2/3 votes for a proposal, so that passage is a foregone conclusion, rule 303 has been interpreted to imply that we still have to wait until the last vote is made to advance the turn.

This is tedious and is likely to eventually leave the game in a permanent hang due to even just one inactive player. Existing rules don't address this. The hang can't be ended by determining a winner by stalemate, because we'd have to literally wait forever to determine that the inactive player will never vote (assuming mortality, we'd have to wait until all of us died, and it is not very satisfying for only player descendants to see who won).

By this proposal, the issue isn't forced. If the proponent does nothing, the old way still applies. The proponent may wish to do nothing in order to earn the full possible quantity of end-of-turn points, and to prevent the non-voters from obtaining dissent points. There is therefore a mild disincentive for proponents to exercise the fast vote option, and we can expect it to be exercised judiciously, e.g. to resume the game in the event of a hang due to a clearly inactive player.
